### PR TITLE
add: page status on to do list

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -9,3 +9,52 @@ order: 0
 - [] Refactor of `index.md`: Rewrite the content... eventually moving part out or the README.
 - [] Refactoring of How To: Try the panels or split in sup pages?
 - [] Reorganize ALL the content with retype tabs, panels, columns, alert, warnings, notes etc.
+
+# Page Status
+
+**Retype Formatting:** Styling Components, Formatting
+
+**Restructuring:** Substantive improvements: simplifying / shortening / presenting images etc.
+
+Name   | Retype Formatting  | Restructuring
+---    | ---
+./api/backend.md |          |                 |
+./api/calendar.md |         |                 |
+./api/console.md |          |                 |
+./api/countless.md |          |                 |
+./api/frontend.md |         |                 |
+./api/i18n.md |         |                 |
+./api/javascript/ajax.md |          |                 |
+./api/javascript/combo-navs.md |          |                 |
+./api/javascript.md |         |                 |
+./api/javascript/navs.md |          |                 |
+./api/javascript/setup.md |         |                 |
+./api/pagy.md |         |                 |
+./extras/arel.md | [!badge variant="success" text="complete"]| [!badge variant="warning" text="TBD: shorten Method description"]|
+./extras/array.md | [!badge variant="success" text="complete"]| [!badge variant="warning" text="TBD: shorten Method description"]|
+./extras/bootstrap.md | [!badge variant="warning" text="TBD"] | [!badge variant="warning" text="TBD"]  |
+./extras/bulma.md | [!badge variant="warning" text="TBD"]        | [!badge variant="warning" text="TBD"] |
+./extras/calendar.md | [!badge variant="success" text="complete"] | [!badge variant="warning" text="TBD"]                |
+./extras/countless.md | [!badge variant="success" text="complete"] | [!badge variant="warning" text="TBD: shorten Method description"] |
+./extras/elasticsearch_rails.md | [!badge variant="success" text="complete"] | [!badge variant="warning" text="TBD: shorten Method description"] |
+./extras/foundation.md | [!badge variant="success" text="complete"] | [!badge variant="warning" text="TBD: shorten Method description"] |
+./extras/gearbox.md | [!badge variant="success" text="complete"] | [!badge variant="warning" text="TBD"] |
+./extras/headers.md | [!badge variant="success" text="complete"] | [!badge variant="warning" text="TBD"] |
+./extras/i18n.md |          |                 |
+./extras/items.md |         |                 |
+./extras/materialize.md |         |                 |
+./extras/meilisearch.md |         |                 |
+./extras/metadata.md |          |                 |
+./extras/navs.md |          |                 |
+./extras/overflow.md |          |                 |
+./extras/searchkick.md |          |                 |
+./extras/semantic.md |          |                 |
+./extras/standalone.md |          |                 |
+./extras/support.md |         |                 |
+./extras/tailwind.md |          |                 |
+./extras/trim.md |          |                 |
+./extras/uikit.md |         |                 |
+./how-to.md |         |                 |
+./migration-guide.md |          |                 |
+./requirements.md |         |                 |
+./TODO.md  |          |                 |


### PR DESCRIPTION
### Why?

So we can track what pages have / haven't been done.

![image](https://user-images.githubusercontent.com/15097447/182551398-8590d70b-fafe-4fe6-996c-a4adc0fbfe96.png)
